### PR TITLE
Initial usys configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# qbs
+build_release
+default
+products

--- a/info.json
+++ b/info.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0",
+  "name": "usys",
+  "type": "core-config"
+}

--- a/install
+++ b/install
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# current dir
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# showing help
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "$(basename "$0") [-h] -- Runs the installation:
+    -h/--help       show this help text
+    --production    installs as production release (under UPIPE_ROOT). Otherwise, if not supplied installs under UPIPE_DEV_ROOT (default)
+    --update-alpha  update alpha release symlink to point to the version provided by info.json
+    --update-beta   update beta release symlink to point to the version provided by info.json
+    --update-stable update stable release symlink to point to the version provided by info.json
+    --update-all    update all release symlinks (alpha, beta and stable) to point to the version provided by info.json"
+  exit 0
+fi
+
+updateReleaseSymlinks() {
+  installRoot="$1"
+  declare info=($(cat "$dir/info.json" | jq -r ".name, .version"))
+  local name=${info[0]}
+  local version=${info[1]}
+
+  for releaseType in stable beta alpha; do
+    # removing current soft-link
+    local targetReleaseLocation="$installRoot/$name/$releaseType"
+    if [[ $* == *--update-$releaseType* || $* == *--update-all* ]]; then
+      if [[ -L "$targetReleaseLocation" ]]; then
+        rm $targetReleaseLocation
+      fi
+    fi
+
+    # creating soft-link
+    if ! [[ -L "$targetReleaseLocation" ]]; then
+      echo "- Updating $releaseType release to point to $version ($targetReleaseLocation -> $(dirname $targetReleaseLocation)/$version)"
+      ln -s $version $targetReleaseLocation
+    fi
+  done
+
+  unset info
+}
+
+# making sure jq is installed
+if ! [ -x "$(command -v jq)" ]; then
+  echo 'ERROR "jq" IS NOT INSTALLED (https://stedolan.github.io/jq/download/).' >&2
+  exit
+fi
+
+# production release
+if [[ $* == *--production* ]]; then
+  # removing any previous build folder
+  if [ -d "build_release" ]; then
+    rm -r "build_release"
+  fi
+
+  # making sure UPIPE_ROOT is defined
+  if [ -z $UPIPE_ROOT ]; then
+    echo "UPIPE_ROOT is not defined"
+    exit 1
+  fi
+
+  # showing a prompt confirmation, in case of a mistake
+  read -r -p "Are you sure you want to run the production release? [y/N] " response
+  if [[ "$response" =~ ^(yes|y)$ ]]; then
+
+    # running installation
+    qbs build_release project.coreConfig:$UPIPE_CORE_CONFIG project.releaseType:production qbs.installRoot:$UPIPE_ROOT
+
+    # updating release
+    updateReleaseSymlinks $UPIPE_ROOT/$UPIPE_CORE_CONFIG $@
+  fi
+
+# development release
+else
+  # making sure UPIPE_DEV_ROOT is defined
+  if [ -z $UPIPE_DEV_ROOT ]; then
+    echo "UPIPE_DEV_ROOT is not defined"
+    exit 1
+  fi
+
+  # TODO: workaround to avoid the installation not detecting
+  # modifications in files and installing a wrong version from the cache
+  # (rather than invalidating the cache).
+  # This issue has been noticed in qbs 1.8.1
+  if [ -d "default" ]; then
+    rm -r "default"
+  fi
+
+  # running installation
+  qbs project.coreConfig:$UPIPE_CORE_CONFIG project.releaseType:dev qbs.installRoot:$UPIPE_DEV_ROOT
+
+  # updating release
+  updateReleaseSymlinks $UPIPE_DEV_ROOT/$UPIPE_CORE_CONFIG $@
+fi

--- a/install.qbs
+++ b/install.qbs
@@ -1,0 +1,63 @@
+import qbs
+import qbs.File
+import qbs.FileInfo
+import qbs.TextFile
+
+Project {
+  id: main
+  property string coreConfig
+  property string releaseType
+
+  Probe {
+    id: info
+    property string fileName: "info.json"
+    property var data
+    configure: {
+      // making sure the info file exists
+      if (!File.exists(fileName)){
+        throw new Error("Cannot find: " + fileName)
+      }
+
+      // parsing info contents
+      data = JSON.parse(new TextFile(fileName).readAll())
+    }
+  }
+
+  Application {
+    Group {
+      qbs.installPrefix: {
+
+        // building the target location
+        targetPrefix = FileInfo.joinPaths(main.coreConfig, info.data.name, info.data.version)
+
+        // making sure to never override a production release
+        targetFullPath = FileInfo.joinPaths(qbs.installRoot, targetPrefix)
+        if (main.releaseType == "production" && File.exists(targetFullPath)) {
+          throw new Error("Cannot override an existent production release: " + targetFullPath)
+        }
+        console.info("Target: " + targetFullPath)
+
+        return targetPrefix
+      }
+
+      Group {
+          name: "Info File"
+          files: [
+            "info.json"
+          ]
+          qbs.install: true
+          qbs.installSourceBase: "./"
+      }
+
+      Group {
+          name: "Active Config"
+          files: [
+            "src/**"
+          ]
+          qbs.install: true
+          qbs.installDir: "config"
+          qbs.installSourceBase: "./src"
+      }
+    }
+  }
+}

--- a/src/env/data/ushotgunSession/default.json
+++ b/src/env/data/ushotgunSession/default.json
@@ -1,0 +1,6 @@
+{
+  "auth": {
+    "scriptName": "upipe",
+    "apiKey": "##################"
+  }
+}

--- a/src/env/defaultFileCreationPermission
+++ b/src/env/defaultFileCreationPermission
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# setting the default permission for file creation
+umask 0002

--- a/src/env/dispatcher
+++ b/src/env/dispatcher
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Environments related with the renderfarm dispatcher.
+# currently these environments are very much
+# deadline centric. However, these names may
+# change when we introduce a new renderfarm manager.
+export DISPATCHER_RENDERFARM_PRIORITY="50"
+export DISPATCHER_RENDERFARM_SPLITSIZE="5"
+export DISPATCHER_RENDERFARM_GROUP="farm"
+export DISPATCHER_RENDERFARM_POOL=""
+export DISPATCHER_RENDERFARM_SECONDARYPOOL=""
+
+# application defaults. The default for the applications is defined by
+# the convention DISPATCHER_RENDERFARM_<APPLICATION>_<OPTION>.
+
+# maya defaults
+export DISPATCHER_RENDERFARM_MAYA_GROUP="$DISPATCHER_RENDERFARM_GROUP"
+export DISPATCHER_RENDERFARM_MAYA_POOL="cg"
+
+# nuke defaults
+export DISPATCHER_RENDERFARM_NUKE_GROUP="$DISPATCHER_RENDERFARM_GROUP"
+export DISPATCHER_RENDERFARM_NUKE_POOL="comp"

--- a/src/env/licenseServers
+++ b/src/env/licenseServers
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# nuke license server (the variable uses this oddy naming convention, keep it like that)
+#export foundry_LICENSE="USE_SERVER=4101@0.0.0.0"
+
+# eddy (plugin for nuke)
+#export VORTECHS_LICENSE_PATH="6200@0.0.0.0"
+
+# bokeh (plugin for nuke)
+#export peregrinel_LICENSE="4313@0.0.0.0"
+
+# optical flares (plugin for nuke)
+#export OPTICAL_FLARES_LICENSE_SERVER_IP="0.0.0.0"
+
+# mocha pro license server
+#export ISL_LICENSE_FILE="27000@0.0.0.0"
+
+# silhouette
+#export SFX_LICENSE_SERVER="4313@0.0.0.0"
+
+# maya / mudbox
+#export ADSKFLEX_LICENSE_FILE="@0.0.0.0"
+#export MAYA2018_AUTODESK_ADLM_THINCLIENT_ENV="$( locres apps/maya/2018 )/AdlmThinClientCustomEnv.xml"
+#export MUDBOX2018_AUTODESK_ADLM_THINCLIENT_ENV="$( locres apps/mudbox/2018 )/AdlmThinClientCustomEnv.xml"

--- a/src/env/network
+++ b/src/env/network
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# ntp server used to sync the time accross all computers (optional)
+#export NTP_SERVER="0.0.0.0"
+
+# folder used to tell the location for temporary files that are
+# shared across the network
+export TEMP_REMOTE_DIR="$UPIPE_ROOT/temp"

--- a/src/env/shotgun
+++ b/src/env/shotgun
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# getting current script folder
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shotgun address
+#export SHOTGUN_URL="https://..."
+
+# session configuration used by ushotgun
+export USHOTGUN_SESSION_CONFIG_PATH="$dir/data/ushotgunSession"

--- a/src/env/version
+++ b/src/env/version
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# user used for publishing versions (optional) in the ingestor
+#export VERSION_PUBLISHER_USER="upub"

--- a/src/postInit
+++ b/src/postInit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script is sourced automatically by ubash after the initialization usys.
+
+# getting current script folder
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# scripts that are going to define new environments
+for executable in $dir/env/* ; do
+  # making sure it's an executable
+  if [[ -f "$executable" &&  -x "$executable" ]]; then
+    source $executable
+  fi
+done


### PR DESCRIPTION
This pull request was created in favor of the upcoming change in ubash [ubash#21](https://github.com/umediayvr/ubash/pull/21) which allow configurations to be represented externally.

The configuration used as example in this pull request came from "UFACILITY" (which is getting deprecated). This example shows how a configuration can be triggered as postInit event. Therefore, this configuration takes affect after the initialization of "usys" to set custom environment variables related with license servers etc...

Note: after this pull request gets merged, UFACILITY repo is going to be deprecated.

# Change log
- Added configuration for usys